### PR TITLE
fix: Replace all 'any' types with proper TypeScript types

### DIFF
--- a/scripts/import-data.ts
+++ b/scripts/import-data.ts
@@ -3,12 +3,12 @@
  * Populates the database with sample NBA player data across multiple seasons
  */
 
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
 // Helper function to generate player stats for different years
-function generatePlayerStats(baseStats: any, year: number, variation: number = 0.1) {
+function generatePlayerStats(baseStats: BasePlayer['baseStats'], year: number, variation: number = 0.1) {
   return {
     ...baseStats,
     season: year,
@@ -388,7 +388,7 @@ const basePlayers: BasePlayer[] = [
 ];
 
 // Generate multi-year data for each player
-const samplePlayers: any[] = [];
+const samplePlayers: Prisma.PlayerCreateManyInput[] = [];
 
 basePlayers.forEach((player: BasePlayer) => {
   // Generate data for 5 years around their peak

--- a/src/app/api/players/route.ts
+++ b/src/app/api/players/route.ts
@@ -5,6 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/database/prisma';
+import { Prisma } from '@prisma/client';
 import type { APIResponse, PlayerSearchResult } from '@/types';
 
 export async function GET(request: NextRequest): Promise<NextResponse<APIResponse<PlayerSearchResult>>> {
@@ -18,7 +19,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<APIRespons
     const position = searchParams.get('position') || '';
 
     // Build simplified where clause
-    const where: any = {};
+    const where: Prisma.PlayerWhereInput = {};
 
     if (search) {
       where.name = {

--- a/src/app/api/teams/[id]/route.ts
+++ b/src/app/api/teams/[id]/route.ts
@@ -5,7 +5,8 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/database/prisma';
-import type { APIResponse } from '@/types';
+import { Prisma } from '@prisma/client';
+import type { APIResponse, Player } from '@/types';
 
 interface UpdateTeamRequest {
   name?: string;
@@ -15,7 +16,7 @@ interface UpdateTeamRequest {
 interface TeamWithPlayers {
   id: number;
   name: string;
-  players: any[];
+  players: Player[];
   createdAt: Date;
 }
 
@@ -95,7 +96,7 @@ export async function GET(
 export async function PUT(
   request: NextRequest,
   { params }: { params: { id: string } }
-): Promise<NextResponse<APIResponse<any>>> {
+): Promise<NextResponse<APIResponse<TeamWithPlayers>>> {
   try {
     const teamId = parseInt(params.id);
     const body: UpdateTeamRequest = await request.json();
@@ -111,7 +112,7 @@ export async function PUT(
       );
     }
 
-    const updateData: any = {};
+    const updateData: Prisma.TeamUpdateInput = {};
 
     if (body.name) {
       updateData.name = body.name;

--- a/src/app/api/teams/route.ts
+++ b/src/app/api/teams/route.ts
@@ -5,7 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/database/prisma';
-import type { APIResponse } from '@/types';
+import type { APIResponse, Player } from '@/types';
 
 interface CreateTeamRequest {
   name: string;
@@ -15,7 +15,7 @@ interface CreateTeamRequest {
 interface Team {
   id: number;
   name: string;
-  players: any[]; // Will be full player objects after fetching
+  players: Player[]; // Will be full player objects after fetching
   createdAt: Date;
 }
 

--- a/src/app/matches/page.tsx
+++ b/src/app/matches/page.tsx
@@ -8,11 +8,12 @@ import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { MatchSimulator } from '@/components/matches/MatchSimulator';
 import { Navbar } from '@/components/layout/Navbar';
+import { Player } from '@/types';
 
 interface Team {
   id: number;
   name: string;
-  players: any[]; // Now contains full player objects
+  players: Player[]; // Now contains full player objects
 }
 
 export default function MatchesPage() {

--- a/src/app/teams/page.tsx
+++ b/src/app/teams/page.tsx
@@ -20,6 +20,13 @@ import { Navbar } from '@/components/layout/Navbar';
 import { SavedTeamsList } from '@/components/teams/SavedTeamsList';
 import { TeamFiller } from '@/components/teams/TeamFiller';
 
+interface SavedTeam {
+  id: number;
+  name: string;
+  players: Player[];
+  createdAt: string;
+}
+
 export default function TeamsPage() {
   const { addPlayer, removePlayer, isPlayerInTeam, loadTeam } = useTeam();
   const [showPlayerSearch, setShowPlayerSearch] = useState(false);
@@ -103,7 +110,7 @@ export default function TeamsPage() {
     setPlayerGroups({});
   };
 
-  const handleLoadTeam = (team: any, targetTeam: 1 | 2) => {
+  const handleLoadTeam = (team: SavedTeam, targetTeam: 1 | 2) => {
     loadTeam({ name: team.name, players: team.players }, targetTeam);
     setShowSavedTeams(false);
   };

--- a/src/components/matches/MatchSimulator.tsx
+++ b/src/components/matches/MatchSimulator.tsx
@@ -7,11 +7,12 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { SimulationEngine } from '@/lib/simulation/engine';
 import { MatchResult, SimulationPlayer, SimulationTeam } from '@/lib/simulation/types';
+import { Player } from '@/types';
 
 interface Team {
   id: number;
   name: string;
-  players: any[]; // Now contains full player objects
+  players: Player[]; // Now contains full player objects
 }
 
 interface MatchSimulatorProps {


### PR DESCRIPTION
## Summary

This PR removes all usage of the `any` type from the codebase and replaces them with proper TypeScript types to improve type safety and validation.

## Changes Made

- **scripts/import-data.ts**: Used `BasePlayer['baseStats']` and `Prisma.PlayerCreateManyInput` types
- **src/app/matches/page.tsx**: Used `Player[]` type for team players
- **src/components/matches/MatchSimulator.tsx**: Used `Player[]` type for team players
- **src/app/teams/page.tsx**: Added `SavedTeam` interface and typed `handleLoadTeam` parameter
- **src/app/api/players/route.ts**: Used `Prisma.PlayerWhereInput` for where clause
- **src/app/api/teams/route.ts**: Used `Player[]` type for team players
- **src/app/api/teams/[id]/route.ts**: Used `Player[]` type and `Prisma.TeamUpdateInput`

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)