### PR TITLE
Import UI primitives to Claude Design (design-sync)

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,60 @@
+# design-sync notes — Basketball Sim UI
+
+This repo is a **Next.js app** (not a published component library), so the sync is
+set up specially. Read this before re-syncing.
+
+## How the build is wired
+
+- **Entry**: `.design-sync/entry.tsx` re-exports only the 9 `src/components/ui`
+  primitives. This keeps esbuild from pulling in the Next.js app/API/Prisma/DuckDB
+  code (which would break the bundle). `cfg.entry` points at it. If you add a new
+  primitive to `src/components/ui`, add an `export * from '@/components/ui/<file>'`
+  line here AND a `componentSrcMap` entry in config.
+- **CSS is compiled manually**. shadcn/Tailwind v4 generates CSS on demand, so there
+  is no shipped stylesheet. `.design-sync/tw-input.css` (mirrors `src/app/globals.css`
+  theme + `@source` globs + a semantic-token safelist) is compiled with the Tailwind
+  CLI into `.design-sync/compiled.css`, which `cfg.cssEntry` points at.
+  **Re-sync step (run before the converter):**
+  `node_modules/.bin/tailwindcss -i .design-sync/tw-input.css -o .design-sync/compiled.css`
+  Recompile whenever component classes OR preview classes change, else new utility
+  classes won't be in the shipped CSS.
+- **Props are hand-written** in `cfg.dtsPropsFor` because there's no dist `.d.ts` to
+  extract from. If a component's props change in source, update its `dtsPropsFor`
+  body. The `extends` clause is dropped for these, so common HTML attributes are
+  enumerated inline.
+
+## Install
+
+- No `node_modules` on a fresh clone. Repo uses `bun` (bun.lock) but a
+  `package-lock.json` is also present. Install with
+  `npm ci --ignore-scripts --no-audit --no-fund` — `--ignore-scripts` skips the
+  native `duckdb`/`sqlite3` builds, which the UI bundle doesn't need.
+- Tailwind CLI: `npm install --no-save --ignore-scripts @tailwindcss/cli@<tailwind version>`.
+- Playwright/Chromium needs OS libs on WSL: run (in a real terminal, needs sudo)
+  `sudo env "PATH=$PATH" .ds-sync/node_modules/.bin/playwright install-deps chromium`.
+
+## Known render warns
+
+- `[GRID_OVERFLOW]` on Alert was resolved with `cfg.overrides.Alert.cardMode: column`.
+- `tokens: 1 missing (below threshold)` — a `var(--*)` referenced with no definition;
+  benign, from the repo's own half-migrated theme.
+
+## Preview / styling gotchas
+
+- `Select` renders its open dropdown via `defaultOpen` + `cfg.overrides.Select`
+  (`cardMode: single`). Radix portals render inside the card fine.
+- `YearSelector` uses a native `<select>` and references `basketball-orange`
+  (an undefined Tailwind color) for focus rings — a no-op in this repo, kept faithful.
+- The repo's theme mixes `oklch(...)` (light mode) and raw HSL triplets (dark mode);
+  `--destructive-foreground` is an HSL triplet with no `--color-destructive-foreground`
+  theme token, so `text-destructive-foreground` does not resolve. Faithful to repo.
+
+## Re-sync risks (what can silently go stale)
+
+- **conventions.md example** uses real component/class names; re-validate them against
+  the fresh build (the base skill's conventions step does this).
+- **compiled.css** is a manual step — forgetting to recompile ships stale utilities.
+- **dtsPropsFor** can drift from source if a component's props change.
+- **entry.tsx / componentSrcMap** must be updated when primitives are added/removed.
+- The safelist in `tw-input.css` only covers tokens with `--color-*` definitions; if
+  the theme adds new token colors, extend the safelist so the agent can use them.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,39 @@
+{
+  "pkg": "basketball",
+  "globalName": "BasketballUI",
+  "projectId": "cc845860-4e04-4b2a-9fc4-95ab24492614",
+  "shape": "package",
+  "entry": ".design-sync/entry.tsx",
+  "srcDir": "src",
+  "tsconfig": "tsconfig.json",
+  "cssEntry": ".design-sync/compiled.css",
+  "readmeHeader": ".design-sync/conventions.md",
+  "componentSrcMap": {
+    "Button": "src/components/ui/button.tsx",
+    "Card": "src/components/ui/card.tsx",
+    "Input": "src/components/ui/input.tsx",
+    "Label": "src/components/ui/label.tsx",
+    "Select": "src/components/ui/select.tsx",
+    "Separator": "src/components/ui/separator.tsx",
+    "Badge": "src/components/ui/badge.tsx",
+    "Alert": "src/components/ui/alert.tsx",
+    "YearSelector": "src/components/ui/year-selector.tsx",
+    "buttonVariants": null,
+    "badgeVariants": null
+  },
+  "dtsPropsFor": {
+    "Button": "/** Visual style variant. */\n  variant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';\n  /** Control size. `icon` is a square icon-only button. */\n  size?: 'default' | 'sm' | 'lg' | 'icon';\n  /** Render as the single child element (Radix Slot) instead of a native <button>. */\n  asChild?: boolean;\n  children?: React.ReactNode;\n  className?: string;\n  disabled?: boolean;\n  type?: 'button' | 'submit' | 'reset';\n  onClick?: React.MouseEventHandler<HTMLButtonElement>;\n  /** Also accepts all standard <button> HTML attributes. */",
+    "Badge": "/** Visual style variant. */\n  variant?: 'default' | 'secondary' | 'destructive' | 'outline';\n  children?: React.ReactNode;\n  className?: string;\n  /** Also accepts all standard <div> HTML attributes. */",
+    "Input": "/** Native input type, e.g. 'text' | 'email' | 'password' | 'number' | 'search'. */\n  type?: React.HTMLInputTypeAttribute;\n  value?: string | number;\n  defaultValue?: string | number;\n  placeholder?: string;\n  disabled?: boolean;\n  readOnly?: boolean;\n  required?: boolean;\n  name?: string;\n  className?: string;\n  onChange?: React.ChangeEventHandler<HTMLInputElement>;\n  /** Also accepts all standard <input> HTML attributes. */",
+    "Label": "/** id of the form control this label is associated with. */\n  htmlFor?: string;\n  children?: React.ReactNode;\n  className?: string;\n  /** Built on @radix-ui/react-label; also accepts its Root props. */",
+    "Select": "/** Controlled selected value. */\n  value?: string;\n  defaultValue?: string;\n  onValueChange?: (value: string) => void;\n  open?: boolean;\n  defaultOpen?: boolean;\n  onOpenChange?: (open: boolean) => void;\n  dir?: 'ltr' | 'rtl';\n  name?: string;\n  disabled?: boolean;\n  required?: boolean;\n  /** Compose with SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel, SelectSeparator (all on window.BasketballUI). */\n  children?: React.ReactNode;",
+    "Separator": "/** Axis of the separator. */\n  orientation?: 'horizontal' | 'vertical';\n  /** When true (default) the separator is purely visual (aria-hidden). */\n  decorative?: boolean;\n  className?: string;",
+    "Alert": "/** Visual style variant. */\n  variant?: 'default' | 'destructive';\n  /** Typically an optional icon plus AlertTitle and AlertDescription. */\n  children?: React.ReactNode;\n  className?: string;\n  /** Compose with AlertTitle and AlertDescription (on window.BasketballUI). */",
+    "Card": "/** Compose with CardHeader, CardTitle, CardDescription, CardContent, CardFooter (all on window.BasketballUI). */\n  children?: React.ReactNode;\n  className?: string;\n  /** Also accepts all standard <div> HTML attributes. */",
+    "YearSelector": "/** Years available to pick from (rendered most-recent first). */\n  availableYears: number[];\n  /** Currently selected year. */\n  selectedYear: number;\n  /** Called with the newly selected year. */\n  onYearChange: (year: number) => void;\n  /** When set and not the selected year, shows a \"Best Year\" shortcut; when equal to selectedYear, shows a \"Peak Season\" badge. */\n  bestYear?: number;\n  className?: string;"
+  },
+  "overrides": {
+    "Select": { "cardMode": "single", "viewport": "320x360", "primaryStory": "PositionMenu" },
+    "Alert": { "cardMode": "column" }
+  }
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,69 @@
+# Basketball Sim UI — conventions
+
+A shadcn/ui-based React design system (New York style) styled with **Tailwind CSS
+v4** and semantic CSS-variable tokens. All components are on `window.BasketballUI`
+(import them from the bundle). Icons in examples come from `lucide-react`.
+
+## Setup / wrapping
+
+No provider or theme wrapper is required — tokens are plain CSS custom properties
+defined on `:root` in `styles.css`, so any component renders styled on its own.
+Light/dark is driven by the `--*` variables (a `.dark` class on an ancestor, or the
+OS `prefers-color-scheme`, flips them). `Select` uses Radix portals internally; no
+setup needed for that either.
+
+## Styling idiom — Tailwind utility classes
+
+Style with **Tailwind utility classes via the `className` prop** (every component
+merges `className` through `cn()` / tailwind-merge, so your classes override the
+defaults). Do NOT invent hex colors — use the semantic token utilities below, which
+map to the DS tokens and adapt to light/dark automatically.
+
+Color roles (each `bg-<role>` pairs with `text-<role>-foreground`):
+
+| Utility | Use |
+|---|---|
+| `bg-background` / `text-foreground` | page surface + body text |
+| `bg-card` / `text-card-foreground` | card/panel surface |
+| `bg-popover` / `text-popover-foreground` | menus, dropdowns |
+| `bg-primary` / `text-primary-foreground` | primary actions, emphasis |
+| `bg-secondary` / `text-secondary-foreground` | secondary surfaces/actions |
+| `bg-muted` / `text-muted-foreground` | subtle fills, captions, labels |
+| `bg-accent` / `text-accent-foreground` | hover/active highlights |
+| `bg-destructive`, `text-destructive` | errors, destructive actions (no `-foreground` token in this theme; the destructive variants set their own text) |
+| `border`, `border-input` | default borders / input borders |
+
+Radius: `rounded-md`, `rounded-lg` (from `--radius`). Layout is standard Tailwind
+(`flex`, `grid`, `gap-*`, `space-y-*`, `p-*`, `w-full`, `h-10`, `text-sm`, …).
+
+## Where the truth lives
+
+- `styles.css` → `@import`s `_ds_bundle.css` (component styles + the compiled utility
+  classes + the `:root` token definitions). Read it before styling.
+- Each component's `<Name>.d.ts` is its prop contract; `<Name>.prompt.md` is its usage
+  note. Compound parts (`CardHeader`, `SelectItem`, `AlertTitle`, …) are all on
+  `window.BasketballUI`.
+
+## Idiomatic example
+
+```tsx
+const { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter, Badge, Button } = window.BasketballUI;
+
+<Card className="w-80">
+  <CardHeader>
+    <CardTitle>LeBron James</CardTitle>
+    <CardDescription>Small Forward · #23</CardDescription>
+  </CardHeader>
+  <CardContent>
+    <div className="grid grid-cols-3 gap-4 text-center">
+      <div><div className="text-xl font-semibold">27.4</div><div className="text-xs text-muted-foreground">PPG</div></div>
+      <div><div className="text-xl font-semibold">7.4</div><div className="text-xs text-muted-foreground">RPG</div></div>
+      <div><div className="text-xl font-semibold">8.3</div><div className="text-xs text-muted-foreground">APG</div></div>
+    </div>
+  </CardContent>
+  <CardFooter className="justify-between">
+    <Badge>Active</Badge>
+    <Button size="sm">View Profile</Button>
+  </CardFooter>
+</Card>
+```

--- a/.design-sync/entry.tsx
+++ b/.design-sync/entry.tsx
@@ -1,0 +1,11 @@
+// design-sync bundle entry — re-exports only the src/components/ui primitives
+// so esbuild bundles the design-system surface, not the Next.js app/DB code.
+export * from '@/components/ui/button';
+export * from '@/components/ui/card';
+export * from '@/components/ui/input';
+export * from '@/components/ui/label';
+export * from '@/components/ui/select';
+export * from '@/components/ui/separator';
+export * from '@/components/ui/badge';
+export * from '@/components/ui/alert';
+export * from '@/components/ui/year-selector';

--- a/.design-sync/previews/Alert.tsx
+++ b/.design-sync/previews/Alert.tsx
@@ -1,0 +1,27 @@
+import { Alert, AlertTitle, AlertDescription } from 'basketball';
+import { Info, AlertTriangle } from 'lucide-react';
+
+export function Default() {
+  return (
+    <Alert className="w-96">
+      <Info className="h-4 w-4" />
+      <AlertTitle>Season starts soon</AlertTitle>
+      <AlertDescription>
+        Set your starting lineup before the first tip-off on October 22.
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+export function Destructive() {
+  return (
+    <Alert variant="destructive" className="w-96">
+      <AlertTriangle className="h-4 w-4" />
+      <AlertTitle>Roster over the cap</AlertTitle>
+      <AlertDescription>
+        Your payroll exceeds the salary cap. Trade or waive a player to
+        continue.
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/.design-sync/previews/Badge.tsx
+++ b/.design-sync/previews/Badge.tsx
@@ -1,0 +1,22 @@
+import { Badge } from 'basketball';
+
+export function Variants() {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <Badge>Active</Badge>
+      <Badge variant="secondary">Bench</Badge>
+      <Badge variant="destructive">Injured</Badge>
+      <Badge variant="outline">Free Agent</Badge>
+    </div>
+  );
+}
+
+export function InlineUsage() {
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <span className="font-medium">Stephen Curry</span>
+      <Badge variant="secondary">PG</Badge>
+      <Badge>All-Star</Badge>
+    </div>
+  );
+}

--- a/.design-sync/previews/Button.tsx
+++ b/.design-sync/previews/Button.tsx
@@ -1,0 +1,36 @@
+import { Button } from 'basketball';
+
+export function Variants() {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button>Start Game</Button>
+      <Button variant="secondary">View Roster</Button>
+      <Button variant="destructive">End Season</Button>
+      <Button variant="outline">Trade Player</Button>
+      <Button variant="ghost">Skip</Button>
+      <Button variant="link">Box Score</Button>
+    </div>
+  );
+}
+
+export function Sizes() {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button size="sm">Small</Button>
+      <Button size="default">Default</Button>
+      <Button size="lg">Large</Button>
+      <Button size="icon" aria-label="Add player">+</Button>
+    </div>
+  );
+}
+
+export function Disabled() {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button disabled>Simulating…</Button>
+      <Button variant="outline" disabled>
+        Locked
+      </Button>
+    </div>
+  );
+}

--- a/.design-sync/previews/Card.tsx
+++ b/.design-sync/previews/Card.tsx
@@ -1,0 +1,58 @@
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+  Button,
+  Badge,
+} from 'basketball';
+
+export function PlayerCard() {
+  return (
+    <Card className="w-80">
+      <CardHeader>
+        <CardTitle>LeBron James</CardTitle>
+        <CardDescription>Small Forward · #23</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-3 gap-4 text-center">
+          <div>
+            <div className="text-xl font-semibold">27.4</div>
+            <div className="text-xs text-muted-foreground">PPG</div>
+          </div>
+          <div>
+            <div className="text-xl font-semibold">7.4</div>
+            <div className="text-xs text-muted-foreground">RPG</div>
+          </div>
+          <div>
+            <div className="text-xl font-semibold">8.3</div>
+            <div className="text-xs text-muted-foreground">APG</div>
+          </div>
+        </div>
+      </CardContent>
+      <CardFooter className="justify-between">
+        <Badge>Active</Badge>
+        <Button size="sm">View Profile</Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+export function TeamSummary() {
+  return (
+    <Card className="w-80">
+      <CardHeader>
+        <CardTitle>Los Angeles Lakers</CardTitle>
+        <CardDescription>Western Conference · Pacific</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-baseline justify-between">
+          <span className="text-sm text-muted-foreground">Record</span>
+          <span className="text-lg font-semibold">52–30</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/.design-sync/previews/Input.tsx
+++ b/.design-sync/previews/Input.tsx
@@ -1,0 +1,26 @@
+import { Input, Label } from 'basketball';
+
+export function Default() {
+  return (
+    <div className="w-80">
+      <Input placeholder="Search players…" />
+    </div>
+  );
+}
+
+export function WithLabel() {
+  return (
+    <div className="w-80 space-y-2">
+      <Label htmlFor="team">Team name</Label>
+      <Input id="team" defaultValue="Golden State Warriors" />
+    </div>
+  );
+}
+
+export function Disabled() {
+  return (
+    <div className="w-80">
+      <Input disabled placeholder="Locked during simulation" />
+    </div>
+  );
+}

--- a/.design-sync/previews/Label.tsx
+++ b/.design-sync/previews/Label.tsx
@@ -1,0 +1,14 @@
+import { Label, Input } from 'basketball';
+
+export function FormField() {
+  return (
+    <div className="w-80 space-y-2">
+      <Label htmlFor="jersey">Jersey number</Label>
+      <Input id="jersey" type="number" placeholder="23" />
+    </div>
+  );
+}
+
+export function Standalone() {
+  return <Label>Minutes per game</Label>;
+}

--- a/.design-sync/previews/Select.tsx
+++ b/.design-sync/previews/Select.tsx
@@ -1,0 +1,26 @@
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from 'basketball';
+
+export function PositionMenu() {
+  return (
+    <div className="w-64">
+      <Select defaultValue="sf" defaultOpen>
+        <SelectTrigger>
+          <SelectValue placeholder="Select position" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="pg">Point Guard</SelectItem>
+          <SelectItem value="sg">Shooting Guard</SelectItem>
+          <SelectItem value="sf">Small Forward</SelectItem>
+          <SelectItem value="pf">Power Forward</SelectItem>
+          <SelectItem value="c">Center</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/.design-sync/previews/Separator.tsx
+++ b/.design-sync/previews/Separator.tsx
@@ -1,0 +1,26 @@
+import { Separator } from 'basketball';
+
+export function Horizontal() {
+  return (
+    <div className="w-80">
+      <div className="space-y-1">
+        <h4 className="text-sm font-medium leading-none">Team Roster</h4>
+        <p className="text-sm text-muted-foreground">15 players signed</p>
+      </div>
+      <Separator className="my-4" />
+      <p className="text-sm text-muted-foreground">Salary cap: $136.0M</p>
+    </div>
+  );
+}
+
+export function Vertical() {
+  return (
+    <div className="flex h-5 items-center gap-4 text-sm">
+      <span>Starters</span>
+      <Separator orientation="vertical" />
+      <span>Bench</span>
+      <Separator orientation="vertical" />
+      <span>Injured</span>
+    </div>
+  );
+}

--- a/.design-sync/previews/YearSelector.tsx
+++ b/.design-sync/previews/YearSelector.tsx
@@ -1,0 +1,27 @@
+import { YearSelector } from 'basketball';
+
+export function SeasonPicker() {
+  return (
+    <div className="w-56">
+      <YearSelector
+        availableYears={[2020, 2021, 2022, 2023, 2024]}
+        selectedYear={2022}
+        bestYear={2024}
+        onYearChange={() => {}}
+      />
+    </div>
+  );
+}
+
+export function PeakSeason() {
+  return (
+    <div className="w-56">
+      <YearSelector
+        availableYears={[2020, 2021, 2022, 2023, 2024]}
+        selectedYear={2024}
+        bestYear={2024}
+        onYearChange={() => {}}
+      />
+    </div>
+  );
+}

--- a/.design-sync/tw-input.css
+++ b/.design-sync/tw-input.css
@@ -1,0 +1,143 @@
+/* design-sync Tailwind input — compiles a static stylesheet (utilities + token
+ * vars) for cfg.cssEntry, since shadcn/Tailwind generates CSS on-demand.
+ * Mirrors src/app/globals.css theme; @source lists what to scan for utilities. */
+@import "tailwindcss";
+
+@plugin "tailwindcss-animate";
+
+@custom-variant dark (&:is(.dark *));
+
+@source "../src/components/**/*.{ts,tsx}";
+@source "../src/app/**/*.{ts,tsx}";
+@source "./previews/**/*.{ts,tsx}";
+
+/* Safelist: ship all semantic token utilities so the design agent can build
+ * with them even though the repo itself only uses a subset. Only tokens with a
+ * valid `--color-*` definition are listed (destructive has no -foreground token). */
+@source inline("{hover:,}bg-{background,foreground,card,popover,primary,secondary,muted,accent,destructive}");
+@source inline("text-{background,foreground,card-foreground,popover-foreground,primary,primary-foreground,secondary-foreground,muted-foreground,accent-foreground,destructive}");
+@source inline("{hover:,}text-{primary-foreground,secondary-foreground,accent-foreground}");
+@source inline("border-{input,destructive}");
+@source inline("ring-ring");
+
+:root {
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: 210 40% 98%;
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --font-sans: system-ui, sans-serif;
+  --font-mono: monospace;
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-chart-5: var(--chart-5);
+  --color-chart-4: var(--chart-4);
+  --color-chart-3: var(--chart-3);
+  --color-chart-2: var(--chart-2);
+  --color-chart-1: var(--chart-1);
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-border: var(--border);
+  --color-destructive: var(--destructive);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted: var(--muted);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
+}
+
+@layer base {
+  * {
+    border-color: hsl(var(--border));
+  }
+  body {
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-family: system-ui, sans-serif;
+    line-height: 1.6;
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ nba.sqlite
 nba.sqlite.zip
 
 /src/generated/prisma
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules
+.design-sync/compiled.css


### PR DESCRIPTION
Adds design-sync inputs so Claude Design's agent builds with this repo's actual UI components.

**Design project:** https://claude.ai/design/p/cc845860-4e04-4b2a-9fc4-95ab24492614

## What's here
Sync inputs only — no changes to app source:
- `.design-sync/config.json` — synth-entry config (pins the 9 `src/components/ui` primitives, hand-written `dtsPropsFor`, Select/Alert card overrides)
- `.design-sync/entry.tsx` — re-exports only the `ui/` primitives so the bundle excludes Next/Prisma/DuckDB code
- `.design-sync/tw-input.css` — Tailwind v4 input (mirrors `globals.css` theme + semantic-token safelist); compiled to the shipped stylesheet
- `.design-sync/conventions.md` — README header teaching the agent this DS's Tailwind idiom + token vocabulary
- `.design-sync/previews/*.tsx` — authored, graded previews for all 9 components
- `.design-sync/NOTES.md` — how the build is wired + re-sync risks

## Synced
9 components (Alert, Badge, Button, Card, Input, Label, Select, Separator, YearSelector), all with authored previews graded good; render check 9/9 clean; zero floor cards.

Re-syncs reuse these inputs and run mostly automatically.